### PR TITLE
Hotfix: Do not divide by adjustment if it equals 0

### DIFF
--- a/include/ListView/ListViewSmarty.php
+++ b/include/ListView/ListViewSmarty.php
@@ -139,10 +139,12 @@ class ListViewSmarty extends ListViewDisplay
 
         $contextMenuObjectsTypes = array();
         foreach ((array)$this->displayColumns as $name => $params) {
-            if (!isset($this->displayColumns[$name]['width'])) {
+            if (!isset($this->displayColumns[$name]['width']) || 0 === $adjustment) {
                 $this->displayColumns[$name]['width'] = 0;
+            } else {
+                $this->displayColumns[$name]['width'] = floor(((int)$this->displayColumns[$name]['width']) / $adjustment);
             }
-            $this->displayColumns[$name]['width'] = floor(((int)$this->displayColumns[$name]['width']) / $adjustment);
+            
             // figure out which contextMenu objectsTypes are required
             if (!empty($params['contextMenu']['objectType'])) {
                 $contextMenuObjectsTypes[$params['contextMenu']['objectType']] = true;


### PR DESCRIPTION
These changes fix issue https://github.com/salesagility/SuiteCRM/issues/7926

The OAuth clients/tokens page has no widths defined, resulting in the totalWidth being 0, and so does the adjustment. The quickfix is to prevent dividing by the variable in such case, avoiding division by 0. When it does, we just set the final value to 0.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->